### PR TITLE
Improve error handling

### DIFF
--- a/addon/components/has-gravatar.js
+++ b/addon/components/has-gravatar.js
@@ -16,7 +16,7 @@ export default Component.extend({
 
     const { email, gravatar, secure } = getProperties(this, 'email', 'gravatar', 'secure');
 
-    return gravatar.hasGravatar(email, secure)
+    return gravatar.hasGravatar(email, secure, 'www.gravatar.com')
       .then((hasGravatar)=> {
         set(this, 'hasGravatar', hasGravatar);
         set(this, 'checking', false);

--- a/addon/services/gravatar.js
+++ b/addon/services/gravatar.js
@@ -8,7 +8,7 @@ const {
 
 
 export default Service.extend({
-  hasGravatar(email, secure) {
+  hasGravatar(email, secure, gravatarHost) {
     if (!email) {
       throw new Error('expecting email');
     }
@@ -16,11 +16,12 @@ export default Service.extend({
     const hash = md5(email);
 
     return new Promise((resolve)=> {
-      ajax(`http${secure ? 's': ''}://www.gravatar.com/avatar/${hash}?d=404`, {
-        complete: ({ status })=> {
-          const NOT_FOUND = 404;
-
-          resolve((status !== NOT_FOUND));
+      ajax(`http${secure ? 's': ''}://${gravatarHost}/avatar/${hash}?d=404`, {
+        complete: function() {
+          resolve(true);
+        },
+        error: function() {
+          resolve(false);
         }
       });
     });

--- a/tests/unit/services/gravatar-test.js
+++ b/tests/unit/services/gravatar-test.js
@@ -6,7 +6,7 @@ test('does not have gravatar', function(assert) {
   const service = this.subject();
   const done = assert.async();
 
-  service.hasGravatar(['foo'])
+  service.hasGravatar(['foo'], true, 'www.gravatar.com')
     .then((result)=> {
       assert.equal(result, false);
       done();
@@ -17,9 +17,20 @@ test('does have a gravatar', function(assert) {
   const service = this.subject();
   const done = assert.async();
 
-  service.hasGravatar(['orahoske.2@gmail.com'])
+  service.hasGravatar(['orahoske.2@gmail.com'], true, 'www.gravatar.com')
     .then((result)=> {
       assert.equal(result, true);
+      done();
+    });
+});
+
+test('returns false if it cannot lookup the domain', function(assert) {
+  const service = this.subject();
+  const done = assert.async();
+
+  service.hasGravatar(['orahoske.2@gmail.com'], true, 'doesnotexist.example.com')
+    .then((result)=> {
+      assert.equal(result, false);
       done();
     });
 });


### PR DESCRIPTION
Connection/DNS lookup errors would not properly return a false
result, giving a blank gravatar if one was branching on g.has.

This commit
 * adds an error handler on the ajax() call
 * on an error returns false
 * makes modifications to enable testing
 * adds tests for new functionality

This fixes bug #66 

This work is funded by New Contest Servcies https://newcontext.com